### PR TITLE
equity curve is now cumulating all trades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+Plots


### PR DESCRIPTION
This corrected version adjusts the equity curve based on trade entries and exits, distinguishing between Long and Short biases and appropriately updating the equity based on net returns. 
If the signal indicates a trade entry, the net return is subtracted from the equity curve.
And if it indicates a trade exit, the net return is added to the equity curve.